### PR TITLE
v21.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ test:
     - boltons.queueutils
     - boltons.setutils
     - boltons.socketutils
-    - boltons.statutils
+    - boltons.statsutils
     - boltons.strutils
     - boltons.tableutils
     - boltons.tbutils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ test:
     - pytest
   commands:
     - pytest --doctest-modules boltons tests
+    - pip check
 
 about:
   home: https://github.com/mahmoud/boltons

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,35 @@ test:
     - boltons
     - tests
     - pytest.ini
+  imports:
+    - boltons
+    - boltons.cacheutils
+    - boltons.debugutils
+    - boltons.dictutils
+    - boltons.ecoutils
+    - boltons.fileutils
+    - boltons.formatutils
+    - boltons.funcutils
+    - boltons.gcutils
+    - boltons.ioutils
+    - boltons.iterutils
+    - boltons.jsonutils
+    - boltons.listutils
+    - boltons.mathutils
+    - boltons.mboxutils
+    - boltons.namedutils
+    - boltons.pathutils
+    - boltons.queueutils
+    - boltons.setutils
+    - boltons.socketutils
+    - boltons.statutils
+    - boltons.strutils
+    - boltons.tableutils
+    - boltons.tbutils
+    - boltons.timeutils
+    - boltons.typeutils
+    - boltons.urlutils
+
   requires:
     - pytest
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,10 +37,23 @@ test:
 
 about:
   home: https://github.com/mahmoud/boltons
+  dev_url: https://github.com/mahmoud/boltons
+  doc_url: https://boltons.readthedocs.io/
   license: BSD-3-Clause
   license_file: LICENSE
+  license_family: BSD
   summary: >
     boltons should be builtins. Boltons is a set of over 160 BSD-licensed, pure-Python utilities in the same spirit as--and yet conspicuously missing from--the standard library.
+  description: |
+    Boltons is a set of pure-Python utilities in the same spirit as — and yet conspicuously missing from — the standard library, including:
+
+      - Atomic file saving, bolted on with fileutils
+      - A highly-optimized OrderedMultiDict, in dictutils
+      - Two types of PriorityQueue, in queueutils
+      - Chunked and windowed iteration, in iterutils
+      - A full-featured TracebackInfo type, for representing stack traces, in tbutils
+      - A lightweight UTC timezone available in timeutils.
+      - Recursive mapping for nested data transforms, with remap
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,8 +22,8 @@ build:
 
 requirements:
   build:
-    - m2-patch  # [win]
-    - patch  # [not win]
+    - m2-patch  # [win and py>39]
+    - patch  # [not win and py>39]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,9 @@ test:
     - pytest
     - pip
   commands:
-    - pytest --doctest-modules boltons tests
+    # tests/test_jsonutils.py::test_reverse_iter_lines fails due to line endings on windows.
+    - pytest -vv --doctest-modules boltons tests -k "not test_reverse_iter_lines"  # [win]
+    - pytest -vv --doctest-modules boltons tests  # [not win]
     - pip check
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,11 @@ build:
 requirements:
   host:
     - pip
-    - python =2.7|>=3.4
+    - python
     - setuptools
+    - wheel
   run:
-    - python =2.7|>=3.4
+    - python
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,10 @@ source:
   fn: boltons-{{ version }}.tar.gz
   url: https://github.com/mahmoud/boltons/archive/{{ version }}.tar.gz
   sha256: {{ hash }}
+  patches:
+    # https://github.com/mahmoud/boltons/commit/270e974975984f662f998c8f6eb0ebebd964de82
+    # Can be removed in next version (>21.0.0)
+    - patches/00_fix_py310_tests.patch  # [py>39]
 
 build:
   noarch: python
@@ -17,6 +21,9 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
+  build:
+    - m2-patch  # [win]
+    - patch  # [not win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,7 @@ test:
 
   requires:
     - pytest
+    - pip
   commands:
     - pytest --doctest-modules boltons tests
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   fn: boltons-{{ version }}.tar.gz
   url: https://github.com/mahmoud/boltons/archive/{{ version }}.tar.gz
   sha256: {{ hash }}
-  patches:
+  patches:  # [py>39]
     # https://github.com/mahmoud/boltons/commit/270e974975984f662f998c8f6eb0ebebd964de82
     # Can be removed in next version (>21.0.0)
     - patches/00_fix_py310_tests.patch  # [py>39]

--- a/recipe/patches/00_fix_py310_tests.patch
+++ b/recipe/patches/00_fix_py310_tests.patch
@@ -1,0 +1,108 @@
+diff --git a/boltons/ecoutils.py b/boltons/ecoutils.py
+index 0ccad70f..91b9412d 100644
+--- a/boltons/ecoutils.py
++++ b/boltons/ecoutils.py
+@@ -354,38 +354,53 @@ def get_profile(**kwargs):
+     return ret
+ 
+ 
+-_real_safe_repr = pprint._safe_repr
+-
+-
+-def _fake_json_dumps(val, indent=2):
+-    # never do this. this is a hack for Python 2.4. Python 2.5 added
+-    # the json module for a reason.
+-    def _fake_safe_repr(*a, **kw):
+-        res, is_read, is_rec = _real_safe_repr(*a, **kw)
+-        if res == 'None':
+-            res = 'null'
+-        if res == 'True':
+-            res = 'true'
+-        if res == 'False':
+-            res = 'false'
+-        if not (res.startswith("'") or res.startswith("u'")):
+-            res = res
+-        else:
+-            if res.startswith('u'):
+-                res = res[1:]
++try:
++    import json
++
++    def dumps(val, indent):
++        if indent:
++            return json.dumps(val, sort_keys=True, indent=indent)
++        return json.dumps(val, sort_keys=True)
++
++except ImportError:
++    _real_safe_repr = pprint._safe_repr
++
++    def _fake_json_dumps(val, indent=2):
++        # never do this. this is a hack for Python 2.4. Python 2.5 added
++        # the json module for a reason.
++        def _fake_safe_repr(*a, **kw):
++            res, is_read, is_rec = _real_safe_repr(*a, **kw)
++            if res == 'None':
++                res = 'null'
++            if res == 'True':
++                res = 'true'
++            if res == 'False':
++                res = 'false'
++            if not (res.startswith("'") or res.startswith("u'")):
++                res = res
++            else:
++                if res.startswith('u'):
++                    res = res[1:]
+ 
+-            contents = res[1:-1]
+-            contents = contents.replace('"', '').replace(r'\"', '')
+-            res = '"' + contents + '"'
+-        return res, is_read, is_rec
++                contents = res[1:-1]
++                contents = contents.replace('"', '').replace(r'\"', '')
++                res = '"' + contents + '"'
++            return res, is_read, is_rec
+ 
+-    pprint._safe_repr = _fake_safe_repr
+-    try:
+-        ret = pprint.pformat(val, indent=indent)
+-    finally:
+-        pprint._safe_repr = _real_safe_repr
++        pprint._safe_repr = _fake_safe_repr
++        try:
++            ret = pprint.pformat(val, indent=indent)
++        finally:
++            pprint._safe_repr = _real_safe_repr
++
++        return ret
++
++    def dumps(val, indent):
++        ret = _fake_json_dumps(val, indent=indent)
++        if not indent:
++            ret = re.sub(r'\n\s*', ' ', ret)
++        return ret
+ 
+-    return ret
+ 
+ 
+ def get_profile_json(indent=False):
+@@ -393,20 +408,6 @@ def get_profile_json(indent=False):
+         indent = 2
+     else:
+         indent = 0
+-    try:
+-        import json
+-
+-        def dumps(val, indent):
+-            if indent:
+-                return json.dumps(val, sort_keys=True, indent=indent)
+-            return json.dumps(val, sort_keys=True)
+-
+-    except ImportError:
+-        def dumps(val, indent):
+-            ret = _fake_json_dumps(val, indent=indent)
+-            if not indent:
+-                ret = re.sub(r'\n\s*', ' ', ret)
+-            return ret
+ 
+     data_dict = get_profile()
+     return dumps(data_dict, indent)


### PR DESCRIPTION
# boltons v21.0.0

jira: https://anaconda.atlassian.net/browse/PKG-1017
upstream: https://github.com/mahmoud/boltons/tree/21.0.0
license: https://github.com/mahmoud/boltons/blob/21.0.0/LICENSE
setup.py: https://github.com/mahmoud/boltons/blob/21.0.0/setup.py

## Changes
- Fork from CF
- Update about section to include description, license_family and urls
- Add patch from upstream for python3.10
- Add missing python requirements

## Notes
- This is a new package for defaults
- Test on Windows is skipped due to false negative:
    - The [test input](https://raw.githubusercontent.com/mahmoud/boltons/master/tests/newlines_test_data.txt) is has `\n` line endings
    - [The test](https://github.com/mahmoud/boltons/blob/master/tests/test_jsonutils.py#L27) uses `os.linesep` which is `\r\n` on Windows.