### PR TITLE
21.0.0 b1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,6 @@ source:
     - patches/00_fix_py310_tests.patch  # [py>39]
 
 build:
-  noarch: python
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
Same as #1 

- Bump build number
- Remove noarch that was accidentally left in previous PR

